### PR TITLE
Fix for using in non-browser environments where window does not exist

### DIFF
--- a/src/VideoScroll.js
+++ b/src/VideoScroll.js
@@ -35,7 +35,7 @@ type Props = {
   children: React.Node
 }
 
-const rAF = window.requestAnimationFrame
+const rAF = typeof window !== 'undefined' ? window.requestAnimationFrame : () => {}
 
 export class VideoScroll extends React.Component<Props, void> {
   // TODO: https://github.com/facebook/flow/pull/5920


### PR DESCRIPTION
Simply adds a check for the existence of window to prevent SSR solutions from crashing when compiled in an environment that doesn't have window. 